### PR TITLE
Split Django settings into prodcution and development settings

### DIFF
--- a/cookiecutter/components/base.py
+++ b/cookiecutter/components/base.py
@@ -45,13 +45,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "cookiecutter.wsgi.application"
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    }
-}
-
 AUTH_PASSWORD_VALIDATORS = [
     {
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",# noqa

--- a/cookiecutter/development.py
+++ b/cookiecutter/development.py
@@ -1,0 +1,17 @@
+from split_settings.tools import optional, include
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+include(
+    'components/base.py',
+)
+
+ALLOWED_HOSTS = ['*']
+
+DEBUG = True
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': str(BASE_DIR / 'db.sqlite3'),
+    }
+}


### PR DESCRIPTION
The base.py file contains the common settings used in all environments, 
while the develop.py file contains the settings specific to the development environment.

The new develop.py file includes settings for the local database, debug mode, 
and development-specific third-party packages. These settings are imported 
by the main settings.py file when the DJANGO_DEVELOP environment variable is set to True.