### PR TITLE
feat: Add drf-spectacular for API documentation==0.26.1

### DIFF
--- a/cookiecutter/components/base.py
+++ b/cookiecutter/components/base.py
@@ -15,7 +15,9 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "storages",
     "rest_framework",
-    'rest_framework_simplejwt',
+    "rest_framework_simplejwt",
+    "drf_spectacular",
+    "drf_spectacular_sidecar",
 ]
 
 MIDDLEWARE = [
@@ -74,19 +76,29 @@ STATIC_ROOT = "static"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 REST_FRAMEWORK = {
-    'DEFAULT_AUTHENTICATION_CLASSES': [
-        'rest_framework.authentication.SessionAuthentication', 
-        'rest_framework.authentication.TokenAuthentication',
-        'rest_framework_simplejwt.authentication.JWTAuthentication', 
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.SessionAuthentication",
+        "rest_framework.authentication.TokenAuthentication",
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
     ],
-    'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.IsAuthenticated', 
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticated",
     ],
-    'DEFAULT_RENDERER_CLASSES': [
-        'rest_framework.renderers.JSONRenderer',
+    "DEFAULT_RENDERER_CLASSES": [
+        "rest_framework.renderers.JSONRenderer",
     ],
-    'DEFAULT_PARSER_CLASSES': [
-        'rest_framework.parsers.JSONParser',
+    "DEFAULT_PARSER_CLASSES": [
+        "rest_framework.parsers.JSONParser",
     ],
-    'EXCEPTION_HANDLER': 'rest_framework.views.exception_handler', 
+    "EXCEPTION_HANDLER": "rest_framework.views.exception_handler",
+}
+SPECTACULAR_SETTINGS = {
+    "TITLE": "",
+    "DESCRIPTION": "",
+    "VERSION": "1.0.0",
+    "SERVE_INCLUDE_SCHEMA": False,
+    "SWAGGER_UI_DIST": "SIDECAR",
+    "SWAGGER_UI_FAVICON_HREF": "SIDECAR",
+    "REDOC_DIST": "SIDECAR",
 }

--- a/cookiecutter/urls.py
+++ b/cookiecutter/urls.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.urls import path, re_path,include
+from django.urls import path, re_path, include
 from django.conf import settings
 from django.views.static import serve
 from rest_framework_simplejwt.views import (
@@ -7,17 +7,25 @@ from rest_framework_simplejwt.views import (
     TokenRefreshView,
 )
 from rest_framework_simplejwt.views import TokenVerifyView
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path('api-auth/', include('rest_framework.urls')),
-    path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
-    path('api/token/verify/', TokenVerifyView.as_view(), name='token_verify'),
+    path("api-auth/", include("rest_framework.urls")),
+    path("api/token/",
+         TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("api/token/refresh/",
+         TokenRefreshView.as_view(), name="token_refresh"),
+    path("api/token/verify/",
+         TokenVerifyView.as_view(), name="token_verify"),
+    path('api/schema/',
+         SpectacularAPIView.as_view(), name='schema'),
+    path('api/schema/redoc/',
+         SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]
 
 if settings.DEBUG:
     urlpatterns += [
-        re_path("media/(?P<path>.*)", serve,
-                {"document_root": settings.MEDIA_ROOT})
+        re_path("media/(?P<path>.*)",
+                serve, {"document_root": settings.MEDIA_ROOT})
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ djangorestframework==3.14.0
 django-filter==22.1
 Markdown==3.4.3
 djangorestframework-simplejwt==5.2.2
+drf-spectacular==0.26.1
+drf-spectacular-sidecar==2023.3.1


### PR DESCRIPTION
This commit adds the `drf-spectacular` package to the project, which provides automatic API schema generation and documentation for the Django REST Framework. The package is configured to generate a Swagger/OpenAPI 2.0 specification that can be used with tools like Swagger UI or ReDoc.

The purpose of this commit is to make it easier for developers to generate and maintain API documentation for the project. The `drf-spectacular` package eliminates the need to manually create and update API documentation, which can save time and reduce errors. The generated documentation also provides a user-friendly interface for exploring and testing the API endpoints.

The `drf-spectacular` package is widely used in the Django community and is well-documented, actively maintained, and compatible with the latest versions of Django and the Django REST Framework.

