### PR TITLE
feat(docs): Add and configure Sphinx documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import django
+
+sys.path.insert(0, os.path.abspath("../../"))
+os.environ["DJANGO_SETTINGS_MODULE"] = "cookiecutter.development"
+django.setup()
+
+project = "django-minimal-cookiecutter"
+copyright = "2023, godfrey-ndungu"
+author = "godfrey-ndungu"
+release = "1.0.0"
+
+extensions = ["sphinx.ext.autodoc",
+              "sphinx.ext.viewcode", "sphinx.ext.napoleon"]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ drf-spectacular-sidecar==2023.3.1
 requests==2.20.1
 redis==4.5.3
 celery==5.2.7
+Sphinx==6.1.3
+sphinx-rtd-theme==1.2.0


### PR DESCRIPTION
This commit adds Sphinx documentation to the Django project to provide better documentation for users and developers. The following changes were made:

- Added  and  as dependencies in
- Created a new  directory to contain the Sphinx configuration and documentation files
- Added  files to the  directory to configure Sphinx