### PR TITLE
feat(docs): Add documentation for core models

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/core/core.rst
+++ b/docs/source/core/core.rst
@@ -1,0 +1,15 @@
+.. django-minimal-cookiecutter documentation master file, created by
+   sphinx-quickstart on Wed Mar 31 2023.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   models/core_models
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/core/models/core_models.rst
+++ b/docs/source/core/models/core_models.rst
@@ -1,0 +1,10 @@
+Core Models
+======================
+
+
+.. toctree::
+   :maxdepth: 2
+
+   trackable_model
+   timestamped_model
+   singleton_model

--- a/docs/source/core/models/singleton_model.rst
+++ b/docs/source/core/models/singleton_model.rst
@@ -1,0 +1,13 @@
+SingletonModel
+==============
+
+The `SingletonModel` is an abstract model that provides functionality for only allowing a single instance of a model to be created. It includes the following field:
+
+- `singleton_id`: A `PositiveIntegerField` that stores the ID of the singleton instance. This field should always have a value of 1.
+
+The `SingletonModel` also includes a custom `save` method that overrides the default behavior to prevent multiple instances from being created. It also includes a `load` method that returns the singleton instance of the model.
+
+.. autoclass:: core.models.SingletonModel
+   :members: save, load
+   :special-members: __doc__
+   :inherited-members:

--- a/docs/source/core/models/timestamped_model.rst
+++ b/docs/source/core/models/timestamped_model.rst
@@ -1,0 +1,12 @@
+TimestampedModel
+================
+
+The `TimestampedModel` is an abstract model that extends the `TrackableModel` and adds additional fields for timestamps. It includes the following fields:
+
+- `date_added`: A `DateTimeField` that automatically stores the date and time when the instance is created.
+- `date_updated`: A `DateTimeField` that automatically stores the date and time when the instance is updated.
+- `date_deleted`: A `DateTimeField` that stores the date and time when the instance is deleted.
+
+.. autoclass:: core.models.TimestampedModel
+   :members:
+   :inherited-members:

--- a/docs/source/core/models/trackable_model.rst
+++ b/docs/source/core/models/trackable_model.rst
@@ -1,0 +1,17 @@
+TrackableModel
+==============
+
+The `TrackableModel` is an abstract model that tracks changes to the model instances. It includes the following fields:
+
+- `created_at`: A `DateTimeField` that automatically stores the date and time when the instance is created.
+- `updated_at`: A `DateTimeField` that automatically stores the date and time when the instance is updated.
+- `created_by`: A `ForeignKey` that stores the user who created the instance.
+- `updated_by`: A `ForeignKey` that stores the user who updated the instance.
+- `history`: A `JSONField` that stores the history of changes to the instance.
+
+The `TrackableModel` also includes a custom `save` method that updates the `history` field whenever an instance is saved.
+
+.. autoclass:: core.models.TrackableModel
+   :members:
+   :exclude-members: save
+   :inherited-members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,19 @@
+.. django-minimal-cookiecutter documentation master file, created by
+   sphinx-quickstart on Wed Mar 31 2023.
+
+Welcome to django-minimal-cookiecutter's documentation!
+
+======================================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   core/core
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`


### PR DESCRIPTION
This commit adds documentation for the core models to provide better understanding of the data model to users and developers. The following changes were made:

- Added  file to the  directory
- Documented the ,, and  models in
- Added links to the  file in the  file

With these changes, users and developers can now access detailed documentation for the core data model by navigating to the  section of the Sphinx documentation.