### PR TITLE
feat: Add custom error handler 

### DIFF
--- a/cookiecutter/components/base.py
+++ b/cookiecutter/components/base.py
@@ -93,7 +93,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PARSER_CLASSES": [
         "rest_framework.parsers.JSONParser",
     ],
-    "EXCEPTION_HANDLER": "rest_framework.views.exception_handler",
+    "EXCEPTION_HANDLER": "core.views.custom_exception_handler",
 }
 SPECTACULAR_SETTINGS = {
     "TITLE": "",

--- a/core/views.py
+++ b/core/views.py
@@ -1,0 +1,24 @@
+from django.core.exceptions import ObjectDoesNotExist
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.views import exception_handler
+from rest_framework.response import Response
+from rest_framework import status
+
+def custom_exception_handler(exc, context):
+    """
+    Custom exception handler to handle PermissionDenied and ObjectDoesNotExist exceptions.
+    """
+    if isinstance(exc, PermissionDenied):
+        return Response({"detail": "You do not have permission to perform this action."}, status=status.HTTP_403_FORBIDDEN)
+    
+    if isinstance(exc, ObjectDoesNotExist):
+        return Response({"detail": "The requested resource does not exist."}, status=status.HTTP_404_NOT_FOUND)
+
+    # Let DRF handle other exceptions
+    response = exception_handler(exc, context)
+
+    if response is not None and response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR:
+        # Customize error message for 500 errors
+        response.data = {"detail": "Internal server error occurred."}
+
+    return response


### PR DESCRIPTION


This commit adds a custom exception handler to the Django REST Framework that handles the exceptions. The handler provides custom error messages and HTTP status codes for these exceptions:

- PermissionDenied: HTTP 403 Forbidden with the detailed message You do not have permission to perform this action.
- ObjectDoesNotExist: HTTP 404 Not Found with detail message The requested resource does not exist.

For other exceptions, the handler lets DRF handle the error and returns the DRF response. The handler also customizes the error message for HTTP 500 Internal Server Error responses, replacing the default DRF message with the Internal server error that occurred.