### PR TITLE
feat: Add load_signals() function to import app-specific signals

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,3 @@
+from .signals_loader import load_signals
+
+load_signals()

--- a/core/signals_loader.py
+++ b/core/signals_loader.py
@@ -1,0 +1,14 @@
+import importlib
+import os
+from django.apps import apps
+
+def load_signals():
+    """
+    Imports any 'signals.py' files found in the app directories.
+    """
+    app_configs = apps.get_app_configs()
+    for app_config in app_configs:
+        app_module = importlib.import_module(app_config.name)
+        signals_path = os.path.join(os.path.dirname(app_module.__file__), 'signals.py')
+        if os.path.exists(signals_path):
+            importlib.import_module(f'{app_config.name}.signals')


### PR DESCRIPTION
This commit adds a  function to an app's file that imports any file found in the app directory. 
The function uses Django's method to get a list of app configurations for all installed apps,
 loops through each app configuration, and checks if a  file exists in the app directory. If a  
file is found, the function imports it using the function from Python's module.

The  function is called in the  file of the app to ensure that any  files in the app directory are
 imported when the app is loaded.