### PR TITLE
Fix  error when accessing list of loaded apps

### DIFF
--- a/cookiecutter/urls.py
+++ b/cookiecutter/urls.py
@@ -8,6 +8,7 @@ from rest_framework_simplejwt.views import (
 )
 from rest_framework_simplejwt.views import TokenVerifyView
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView
+from core.signals_loader import load_signals
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -29,3 +30,6 @@ if settings.DEBUG:
         re_path("media/(?P<path>.*)",
                 serve, {"document_root": settings.MEDIA_ROOT})
     ]
+
+
+load_signals()

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,3 +1,0 @@
-from .signals_loader import load_signals
-
-load_signals()


### PR DESCRIPTION
The error was caused by trying to access the list of loaded apps before the 
Django app registry had finished loading them. To fix this,I have called load_signales()
 from main urls instead of core  __init__ file