### PR TITLE
Fix core signal loader

### DIFF
--- a/core/apps.py
+++ b/core/apps.py
@@ -4,3 +4,7 @@ from django.apps import AppConfig
 class CoreConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "core"
+
+    def ready(self):
+        from core.signals_loader import load_signals # noqa
+        load_signals()


### PR DESCRIPTION
Fix the core signal loader by adding the `ready()` method in the app config
The previous app implementation did not have the `ready()` method in the app config, which caused the core signal loader to fail. By adding the `ready()` method in the app config, we are able to initialize the app and load the necessary signals properly.

This commit fixes the issue and ensures the core signal loader works as expected.
