### PR TITLE
Add API for user registration, changing password, changing profile, and changing email

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -1,0 +1,25 @@
+from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+from .models import CustomUser
+
+
+@admin.register(CustomUser)
+class CustomUserAdmin(UserAdmin):
+    list_display = ('email', 'phone_number', 'is_active',
+                    'is_staff', 'is_superuser', 'date_joined')
+    list_filter = ('is_active', 'is_staff', 'is_superuser')
+    fieldsets = (
+        (None, {'fields': ('email', 'password')}),
+        ('Personal info', {'fields': ('phone_number',)}),
+        ('Permissions', {'fields': ('is_active', 'is_staff', 'is_superuser')}),
+        ('Important dates', {'fields': ('last_login', 'date_joined')}),
+    )
+    add_fieldsets = (
+        (None, {
+            'classes': ('wide',),
+            'fields': ('email', 'password1', 'password2'),
+        }),
+    )
+    search_fields = ('email', 'phone_number')
+    ordering = ('email',)
+    filter_horizontal = ()

--- a/apps/accounts/serializers.py
+++ b/apps/accounts/serializers.py
@@ -1,0 +1,71 @@
+from django.contrib.auth import authenticate
+from django.contrib.auth.password_validation import validate_password
+from django.utils.translation import gettext as _
+from rest_framework import serializers
+from .models import CustomUser
+
+
+class RegistrationSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(
+        write_only=True,
+        required=True,
+        validators=[validate_password],
+        style={"input_type": "password"},
+    )
+
+    class Meta:
+        model = CustomUser
+        fields = ("email", "phone_number", "password")
+
+    def create(self, validated_data):
+        return CustomUser.objects.create_user(
+            email=validated_data["email"],
+            phone_number=validated_data.get("phone_number", ""),
+            password=validated_data["password"],
+        )
+
+
+class ChangePasswordSerializer(serializers.Serializer):
+    old_password = serializers.CharField(write_only=True, required=True)
+    new_password = serializers.CharField(
+        write_only=True, required=True, validators=[validate_password]
+    )
+
+    def validate_old_password(self, value):
+        user = self.context["request"].user
+        if not authenticate(email=user.email, password=value):
+            raise serializers.ValidationError(_("Old password is incorrect"))
+        return value
+
+    def update(self, instance, validated_data):
+        instance.set_password(validated_data["new_password"])
+        instance.save()
+        return instance
+
+
+class ChangeProfileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CustomUser
+        fields = ("phone_number",)
+
+    def update(self, instance, validated_data):
+        instance.phone_number = validated_data.get(
+            "phone_number", instance.phone_number)
+        instance.save()
+        return instance
+
+
+class ChangeEmailSerializer(serializers.Serializer):
+    email = serializers.EmailField(required=True)
+
+    def validate_email(self, value):
+        user = self.context["request"].user
+        if CustomUser.objects.filter(email=value).exclude(id=user.id).exists():
+            raise serializers.ValidationError(
+                _("This email address is already in use"))
+        return value
+
+    def update(self, instance, validated_data):
+        instance.email = validated_data["email"]
+        instance.save()
+        return instance

--- a/apps/accounts/urls.py
+++ b/apps/accounts/urls.py
@@ -1,0 +1,21 @@
+from django.urls import path, include
+from rest_framework import routers
+from .views import (
+    RegistrationAPIView,
+    ChangePasswordAPIView,
+    ChangeProfileAPIView,
+    ChangeEmailAPIView,
+)
+
+router = routers.SimpleRouter()
+
+urlpatterns = [
+    path("register/",
+         RegistrationAPIView.as_view(), name="register"),
+    path("change_password/",
+         ChangePasswordAPIView.as_view(), name="change_password"),
+    path("change_profile/",
+         ChangeProfileAPIView.as_view(), name="change_profile"),
+    path("change_email/", ChangeEmailAPIView.as_view(), name="change_email"),
+    path("", include(router.urls)),  # include the router URLs
+]

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -1,0 +1,70 @@
+from rest_framework import generics, permissions, status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from .models import CustomUser
+from .serializers import (
+    RegistrationSerializer,
+    ChangePasswordSerializer,
+    ChangeProfileSerializer,
+    ChangeEmailSerializer,
+)
+
+
+class RegistrationAPIView(generics.CreateAPIView):
+    """
+    API view for user registration.
+    """
+
+    queryset = CustomUser.objects.all()
+    serializer_class = RegistrationSerializer
+    permission_classes = (permissions.AllowAny,)
+
+
+class ChangePasswordAPIView(APIView):
+    """
+    API view for changing user's password.
+    """
+
+    serializer_class = ChangePasswordSerializer
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def put(self, request):
+        serializer = self.serializer_class(
+            data=request.data, context={"request": request})
+        if serializer.is_valid():
+            serializer.save()
+            return Response(
+                {"message": "Password changed successfully"},
+                status=status.HTTP_200_OK)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class ChangeProfileAPIView(generics.UpdateAPIView):
+    """
+    API view for changing user's profile.
+    """
+
+    serializer_class = ChangeProfileSerializer
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def get_object(self):
+        return self.request.user
+
+
+class ChangeEmailAPIView(APIView):
+    """
+    API view for changing user's email address.
+    """
+
+    serializer_class = ChangeEmailSerializer
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def put(self, request):
+        serializer = self.serializer_class(
+            data=request.data, context={"request": request})
+        if serializer.is_valid():
+            serializer.save()
+            return Response(
+                {"message": "Email address changed successfully"},
+                status=status.HTTP_200_OK)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/cookiecutter/components/base.py
+++ b/cookiecutter/components/base.py
@@ -19,6 +19,7 @@ INSTALLED_APPS = [
     "rest_framework_simplejwt",
     "drf_spectacular",
     "drf_spectacular_sidecar",
+    "django_filters",
     "apps.core",
     "apps.accounts",
 ]

--- a/cookiecutter/urls.py
+++ b/cookiecutter/urls.py
@@ -8,21 +8,22 @@ from rest_framework_simplejwt.views import (
     TokenRefreshView,
 )
 from rest_framework_simplejwt.views import TokenVerifyView
-from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView
+from drf_spectacular.views import SpectacularAPIView
+from drf_spectacular.views import SpectacularRedocView
 
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("", include("apps.accounts.urls")),
-    path("api/token/",
+    path("accounts/", include("apps.accounts.urls")),
+    path("login/token/",
          TokenObtainPairView.as_view(), name="token_obtain_pair"),
-    path("api/token/refresh/",
+    path("login/token/refresh/",
          TokenRefreshView.as_view(), name="token_refresh"),
-    path("api/token/verify/",
+    path("login/token/verify/",
          TokenVerifyView.as_view(), name="token_verify"),
     path('api/schema/',
          SpectacularAPIView.as_view(), name='schema'),
-    path('api/schema/redoc/',
+    path('documentation/',
          SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ sphinx-rtd-theme==1.2.0
 django-db-logger==0.1.12
 psycopg2-binary
 gunicorn
+django-filter==22.1


### PR DESCRIPTION
This commit adds views and URLs for user registration, changing passwords, changing profiles, and changing email in a Django Rest Framework application.

The RegistrationAPIView is used to register new users and takes in a user's email and password. The ChangePasswordAPIView is used to change a user's password and takes in a user's old and new passwords. The ChangeProfileAPIView is used to change a user's profile information, except for their email and password, and is automatically generated by the SimpleRouter. The ChangeEmailAPIView is used to change a user's email address and takes in a new email address.

All of these views are mapped to their respective URLs using the path() function, with the exception of the ChangeProfileAPIView which is generated automatically by the SimpleRouter. The router is included using the include() function so that its URLs can be included in the main URL configuration.