### PR TITLE
feat: Add API view for listing and retrieving account details

### DIFF
--- a/apps/accounts/serializers.py
+++ b/apps/accounts/serializers.py
@@ -106,3 +106,9 @@ class ChangeEmailSerializer(serializers.Serializer):
         instance.email = validated_data["email"]
         instance.save()
         return instance
+
+
+class CustomUserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CustomUser
+        fields = "__all__"

--- a/apps/accounts/urls.py
+++ b/apps/accounts/urls.py
@@ -5,9 +5,12 @@ from .views import (
     ChangePasswordAPIView,
     ChangeProfileAPIView,
     ChangeEmailAPIView,
+    CustomUserViewSet
 )
 
 router = routers.SimpleRouter()
+
+router.register(r'users', CustomUserViewSet, basename='users')
 
 urlpatterns = [
     path("register/",


### PR DESCRIPTION
This commit adds a new API view to the application that allows for listing all user accounts and retrieving the details of individual accounts using the account's primary key (pk).

The view only allows the GET, PATCH, POST, and PUT HTTP methods, and is restricted to admin users only using the IsAdminUser permission class.

The view is implemented using Django's ModelViewSet, which provides convenient built-in support for CRUD operations on a model. The view is registered using a router to simplify URL routing.

This feature improves the user management capabilities of the application by providing a centralized API endpoint for managing user accounts.