### PR TITLE
Add django-cors-headers==3.14.0

### DIFF
--- a/cookiecutter/components/base.py
+++ b/cookiecutter/components/base.py
@@ -21,12 +21,14 @@ INSTALLED_APPS = [
     "drf_spectacular",
     "drf_spectacular_sidecar",
     "django_filters",
+    "corsheaders",
     "apps.core",
     "apps.accounts",
 ]
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -154,3 +156,14 @@ SIMPLE_JWT = {
     "REFRESH_TOKEN_LIFETIME": timedelta(days=1*15),
     "UPDATE_LAST_LOGIN": True,
 }
+
+CORS_ALLOW_ALL_ORIGINS = False
+
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost:8080",
+    "http://127.0.0.1:8000",
+]
+
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    r"^https://\w+\.example\.com$",  # add custom domain
+]

--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -18,3 +18,4 @@ django-db-logger==0.1.12
 psycopg2-binary
 Django==3.2.18
 importlib-metadata==4.13.0
+django-cors-headers==3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ django-db-logger==0.1.12
 psycopg2-binary
 gunicorn
 django-filter==22.1
+django-cors-headers==3.14.0


### PR DESCRIPTION
This commit adds the django-cors-headers package to the project's requirements.txt file, and adds the necessary settings to the project's settings.py file to enable cross-origin resource sharing (CORS) for the application.